### PR TITLE
Reduce Docker image size

### DIFF
--- a/docker/orthanc/Dockerfile
+++ b/docker/orthanc/Dockerfile
@@ -296,50 +296,64 @@ RUN wget https://orthanc.uclouvain.be/downloads/linux-standard-base/osimis-web-v
 ################################# the image that will run Orthanc dynamicaly linked (intermediate version without vcpkg builds)
 FROM orthanc-runner-base AS orthanc-no-vcpkg
 
-RUN mkdir -p /etc/orthanc
-RUN mkdir -p /usr/share/orthanc/plugins-available && \
-	ln --symbolic /usr/share/orthanc/plugins-available /usr/share/orthanc/plugins-disabled && \
-	echo "plugins-disabled is deprecated, please source plugins from plugins-available instead" >/usr/share/orthanc/plugins-disabled.README
-RUN mkdir -p /usr/share/orthanc/plugins/
+# always create an 'orthanc' group (gid=999) and an orthanc user (uid=999)
+# and grants him all permissions on files that can be modified by the docker-entrypoint.sh
+# The default root users can still access these files too.
+# for the /etc/hostid -> we must make sure the file exists to grant the permission
+RUN groupadd --system orthanc --gid=999; \
+    useradd --system --gid=orthanc --uid=999 --home-dir=/var/lib/orthanc --shell=/bin/false orthanc;
 
-COPY --from=build-orthanc /build/Orthanc /usr/local/bin/
-COPY --from=build-orthanc /build/libModalityWorklists.so /usr/share/orthanc/plugins-available/
-COPY --from=build-orthanc /build/libServeFolders.so /usr/share/orthanc/plugins-available/
-COPY --from=build-orthanc /build/libHousekeeper.so /usr/share/orthanc/plugins-available/
-COPY --from=build-orthanc /build/libConnectivityChecks.so /usr/share/orthanc/plugins-available/
-COPY --from=build-orthanc /build/libDelayedDeletion.so /usr/share/orthanc/plugins-available/
-COPY --from=build-orthanc /build/libMultitenantDicom.so /usr/share/orthanc/plugins-available/
+RUN mkdir -p /etc/orthanc && \
+      mkdir -p /usr/share/orthanc/plugins-available && \
+      ln --symbolic /usr/share/orthanc/plugins-available /usr/share/orthanc/plugins-disabled && \
+      echo "plugins-disabled is deprecated, please source plugins from plugins-available instead" >/usr/share/orthanc/plugins-disabled.README && \
+      mkdir -p /usr/share/orthanc/plugins/ && \
+      mkdir -p /var/lib/orthanc; \
+      chown -R orthanc:orthanc /var/lib/orthanc; \
+      chown -R orthanc:orthanc /tmp; \
+      chown -R orthanc:orthanc /usr/share/orthanc/plugins; \
+      chown -R orthanc:orthanc /usr/share/orthanc/plugins-available; \
+      echo not-generated > /etc/hostid; \
+      chown orthanc:orthanc /etc/hostid
+
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/Orthanc /usr/local/bin/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libModalityWorklists.so /usr/share/orthanc/plugins-available/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libServeFolders.so /usr/share/orthanc/plugins-available/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libHousekeeper.so /usr/share/orthanc/plugins-available/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libConnectivityChecks.so /usr/share/orthanc/plugins-available/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libDelayedDeletion.so /usr/share/orthanc/plugins-available/
+COPY --from=build-orthanc --chown=orthanc:orthanc --chmod=755 /build/libMultitenantDicom.so /usr/share/orthanc/plugins-available/
 # RUN ldd /usr/bin/Orthanc
 
-COPY --from=build-plugin-pg /build/libOrthancPostgreSQLIndex.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-pg /build/libOrthancPostgreSQLStorage.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-mysql /build/libOrthancMySQLIndex.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-mysql /build/libOrthancMySQLStorage.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-transfers /build/libOrthancTransfers.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-dicomweb /build/libOrthancDicomWeb.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-wsi /build/libOrthancWSI.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-wsi /downloads/OrthancWSIDicomToTiff /usr/local/bin/
-COPY --from=build-plugin-wsi /downloads/OrthancWSIDicomizer /usr/local/bin/
-COPY --from=build-plugin-auth /build/libOrthancAuthorization.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-owv /build/libOrthancWebViewer.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-python /build/libOrthancPython.so /usr/share/orthanc/plugins-available/
-COPY --from=build-gdcm /build/libOrthancGdcm.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-odbc /build/libOrthancOdbcIndex.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-odbc /build/libOrthancOdbcStorage.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-tcia /build/libOrthancTcia.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-indexer /build/libOrthancIndexer.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-neuro /build/libOrthancNeuro.so /usr/share/orthanc/plugins-available/
-COPY --from=build-stone-viewer /build/libStoneWebViewer.so /usr/share/orthanc/plugins-available/
-COPY --from=build-oe2 /build/libOrthancExplorer2.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-volview /build/libOrthancVolView.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-ohif /build/libOrthancOHIF.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-stl /build/libOrthancSTL.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-advanced-storage /build/libAdvancedStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-pg --chown=orthanc:orthanc --chmod=755 /build/libOrthancPostgreSQLIndex.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-pg --chown=orthanc:orthanc --chmod=755 /build/libOrthancPostgreSQLStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-mysql --chown=orthanc:orthanc --chmod=755 /build/libOrthancMySQLIndex.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-mysql --chown=orthanc:orthanc --chmod=755 /build/libOrthancMySQLStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-transfers --chown=orthanc:orthanc --chmod=755 /build/libOrthancTransfers.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-dicomweb --chown=orthanc:orthanc --chmod=755 /build/libOrthancDicomWeb.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-wsi --chown=orthanc:orthanc --chmod=755 /build/libOrthancWSI.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-wsi --chown=orthanc:orthanc --chmod=755 /downloads/OrthancWSIDicomToTiff /usr/local/bin/
+COPY --from=build-plugin-wsi --chown=orthanc:orthanc --chmod=755 /downloads/OrthancWSIDicomizer /usr/local/bin/
+COPY --from=build-plugin-auth --chown=orthanc:orthanc --chmod=755 /build/libOrthancAuthorization.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-owv --chown=orthanc:orthanc --chmod=755 /build/libOrthancWebViewer.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-python --chown=orthanc:orthanc --chmod=755 /build/libOrthancPython.so /usr/share/orthanc/plugins-available/
+COPY --from=build-gdcm --chown=orthanc:orthanc --chmod=755 /build/libOrthancGdcm.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-odbc --chown=orthanc:orthanc --chmod=755 /build/libOrthancOdbcIndex.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-odbc --chown=orthanc:orthanc --chmod=755 /build/libOrthancOdbcStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-tcia --chown=orthanc:orthanc --chmod=755 /build/libOrthancTcia.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-indexer --chown=orthanc:orthanc --chmod=755 /build/libOrthancIndexer.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-neuro --chown=orthanc:orthanc --chmod=755 /build/libOrthancNeuro.so /usr/share/orthanc/plugins-available/
+COPY --from=build-stone-viewer --chown=orthanc:orthanc --chmod=755 /build/libStoneWebViewer.so /usr/share/orthanc/plugins-available/
+COPY --from=build-oe2 --chown=orthanc:orthanc --chmod=755 /build/libOrthancExplorer2.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-volview --chown=orthanc:orthanc --chmod=755 /build/libOrthancVolView.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-ohif --chown=orthanc:orthanc --chmod=755 /build/libOrthancOHIF.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-stl --chown=orthanc:orthanc --chmod=755 /build/libOrthancSTL.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-advanced-storage --chown=orthanc:orthanc --chmod=755 /build/libAdvancedStorage.so /usr/share/orthanc/plugins-available/
 
-COPY --from=build-downloader /downloads/libOsimisWebViewer.so /usr/share/orthanc/plugins-available/
-COPY --from=build-downloader /downloads/libOsimisWebViewerAlpha.so /usr/share/orthanc/plugins-available/
+COPY --from=build-downloader --chown=orthanc:orthanc --chmod=755 /downloads/libOsimisWebViewer.so /usr/share/orthanc/plugins-available/
+COPY --from=build-downloader --chown=orthanc:orthanc --chmod=755 /downloads/libOsimisWebViewerAlpha.so /usr/share/orthanc/plugins-available/
 
-COPY --from=build-s3-object-storage /build/libOrthancAwsS3Storage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-s3-object-storage --chown=orthanc:orthanc --chmod=755 /build/libOrthancAwsS3Storage.so /usr/share/orthanc/plugins-available/
 
 # If the target architecture is not AMD64, then delete the OsimisWebViewer &
 # OsimisWebViewerAlpha plugin as they are only compatible with AMD64 builds
@@ -348,8 +362,8 @@ RUN if [[ ! -z "$PLATFORM" ]] && [[ "$PLATFORM" != "linux/amd64" ]]; then \
 	rm /usr/share/orthanc/plugins-available/libOsimisWebViewerAlpha.so; \
 	fi
 
-RUN chmod +x /usr/share/orthanc/plugins-available/*
-RUN chmod +x /usr/local/bin/*
+# RUN chmod +x /usr/share/orthanc/plugins-available/*
+# RUN chmod +x /usr/local/bin/*
 
 RUN pip install envsubst==0.1.5 --break-system-packages
 
@@ -373,20 +387,6 @@ COPY test-aliveness.py /probes/
 # cleanup unnecessary packages that can trigger errors during security scan
 RUN apt purge --assume-yes build-essential perl bzip2 gnupg xdg-user-dirs && apt --assume-yes autoremove
 
-
-# always create an 'orthanc' group (gid=999) and an orthanc user (uid=999)
-# and grants him all permissions on files that can be modified by the docker-entrypoint.sh
-# The default root users can still access these files too.
-# for the /etc/hostid -> we must make sure the file exists to grant the permission
-RUN groupadd --system orthanc --gid=999; \
-    useradd --system --gid=orthanc --uid=999 --home-dir=/var/lib/orthanc --shell=/bin/false orthanc; \
-    mkdir -p /var/lib/orthanc; \
-    chown -R orthanc:orthanc /var/lib/orthanc; \
-    chown -R orthanc:orthanc /tmp; \
-    chown -R orthanc:orthanc /usr/share/orthanc/plugins; \
-    chown -R orthanc:orthanc /usr/share/orthanc/plugins-available; \
-    echo not-generated > /etc/hostid; \
-    chown orthanc:orthanc /etc/hostid
 
 
 ################################# the "full" image that will run Orthanc dynamicaly linked (final version with vcpkg builds and Microsoft unixodbc)
@@ -412,11 +412,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=build-google-object-storage --chown=orthanc:orthanc /build/libOrthancGoogleCloudStorage.so /usr/share/orthanc/plugins-available/
-COPY --from=build-azure-object-storage --chown=orthanc:orthanc /build/libOrthancAzureBlobStorage.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-java --chown=orthanc:orthanc /build/libOrthancJava.so /usr/share/orthanc/plugins-available/
-COPY --from=build-plugin-java --chown=orthanc:orthanc /build/OrthancJavaSDK.jar /java
-
-RUN chmod +x /usr/share/orthanc/plugins-available/*
-RUN chmod +x /usr/local/bin/*
-
+COPY --from=build-google-object-storage --chown=orthanc:orthanc --chmod=775 /build/libOrthancGoogleCloudStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-azure-object-storage --chown=orthanc:orthanc --chmod=775 /build/libOrthancAzureBlobStorage.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-java --chown=orthanc:orthanc --chmod=775 /build/libOrthancJava.so /usr/share/orthanc/plugins-available/
+COPY --from=build-plugin-java --chown=orthanc:orthanc --chmod=775 /build/OrthancJavaSDK.jar /java

--- a/docker/orthanc/Dockerfile.runner-base
+++ b/docker/orthanc/Dockerfile.runner-base
@@ -33,7 +33,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get --assume-yes install --no-install-recommends libmysqlclient21 && \
   apt-get --assume-yes install --no-install-recommends unixodbc && \
   apt-get --assume-yes install --no-install-recommends libopenslide0 && \
-  apt-get --assume-yes install --no-install-recommends libcrypto++ && \
+  apt-get --assume-yes install --no-install-recommends libcrypto++8 && \
   apt-get --assume-yes install --no-install-recommends libcpprest && \
   apt-get --assume-yes install --no-install-recommends libprotobuf32 && \
   apt-get --assume-yes install --no-install-recommends pkg-config && \


### PR DESCRIPTION
## Problem

The Orthanc docker image size is rather large and has room to be reduced substantially without affecting functionality. The reasons for its size are two-fold:
1. As stated in #29, most files in `/usr/share/orthanc/plugins-available/` have separate copies in various layers of the image due to `chown` and `chmod` commands being run in separate steps. This creates a new copy in the layer where the permissions or ownership are modified even though the contents of the file is unchanged. Thus, these files contribute 2 or 3 times to the size of the final image. See output from [dive](https://github.com/wagoodman/dive):

    <img width="848" height="332" alt="Image" src="https://github.com/user-attachments/assets/2987c231-e2ee-4c63-a2e0-d1048b488b04" />

2. It appears that many extraneous packages are being installed due to `apt-get` interpreting `libcrypto++` as a regex and installing all matching packages:  
    <img width="800" height="861" alt="image" src="https://github.com/user-attachments/assets/90a2c447-0a16-4c28-a02e-95b884680405" />

## Resolution
1. When generating the final image I have moved the user and group creation as well as some directory creation to the first step. I have then added `--chown` and `--chmod` flags to the `COPY` directives, allowing all of these files to be generated with the proper ownership and permissions in one shot and eliminating the duplicate copies in image layers. This reduced the uncompressed image size by at least `500MB`:

    <img width="854" height="323" alt="Image" src="https://github.com/user-attachments/assets/a447211b-8d2b-4474-a669-8620915d3874" />

2. I made an educated guess and changed to `libcrypto++8`. I could not find `libcrypto++` as part of the documented dependencies of Orthanc and so I am unsure exactly where and how this is used. Please advise if different or additional package(s) are needed. Orthanc was able to successfully build and run (with no config). This change further reduced the uncompressed size by another `700MB`:
  
    <img width="565" height="315" alt="image" src="https://github.com/user-attachments/assets/b141f9bf-e98e-42d5-9348-5f1c35aeafd7" />

Note that this improvement is not just for the final image, but for the runner and builder base images as well:
 
<img width="912" height="127" alt="image" src="https://github.com/user-attachments/assets/92417e87-59ec-4b1c-89d7-018fb8cd0f85" />

Please let me know if I have covered everything needed to contribute here. Also, I was unsure if there is any automated testing of the Docker images that could be run to validate that these changes don't break anything. Happy to test further and make changes as necessary.